### PR TITLE
Fix suspected 'canvasContect' typo

### DIFF
--- a/src/WaveView.js
+++ b/src/WaveView.js
@@ -399,7 +399,7 @@ class WaveView {
      */
     _removeCanvasHandlers() {
         if (this._mouseClickHandler) {
-            this.canvasContect.canvas
+            this.canvasContext.canvas
                 .removeEventListener('click', this._mouseClickHandler);
         }
     }


### PR DESCRIPTION
I am getting "ERROR TypeError: Cannot read property 'canvas' of undefined" when destroying a waveplayer instance.  I've traced it back to line 402 of WaveView.js.  It appears this may be a typo.  Is this supposed to be `canvasContext` rather than `canvasContect`?  If so, here is a pull request to fix the issue.